### PR TITLE
Fix attribute escaping deprecation warning

### DIFF
--- a/app/components/lookbook/tag_component.rb
+++ b/app/components/lookbook/tag_component.rb
@@ -20,7 +20,14 @@ module Lookbook
     end
 
     def self.escape_attribute_key
-      @escape_attribute_key ||= (Gem::Version.new(Rails.version) < Gem::Version.new("6.1.5.1")) ? :escape_attributes : :escape
+      @escape_attribute_key ||= (
+        (
+          Gem::Version.new(Rails.version) < Gem::Version.new("5.2.7.1")
+        ) || (
+          Gem::Version.new(Rails.version) >= Gem::Version.new("6") &&
+          Gem::Version.new(Rails.version) < Gem::Version.new("6.1.5.1")
+        )
+      ) ? :escape_attributes : :escape
     end
   end
 end


### PR DESCRIPTION
escape_attribute_key has also been deprecated in the 5.2 branch since version 5.2.7.1